### PR TITLE
Suppressed hydration warning

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,7 @@ export default function RootLayout({
           src="/script/schema.json"
         />
       </head>
-      <body className={inter.className}>
+      <body className={inter.className} suppressHydrationWarning>
         <Providers>
           <div data-scroll-container>
             <NextTopLoader color={loaderColor} height={5} />


### PR DESCRIPTION
This warning appears in Next.js due to extra attributes added to the DOM by browser extensions, causing a mismatch between server-rendered and client-rendered HTML.